### PR TITLE
Add console script for running the module

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,4 +14,4 @@ From source :
 
 ## Executing a sketch
 
-`python{3,} -m pyprocessing path/to/sketch.py`
+`pyprocessing path/to/sketch.py`

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,10 @@ setup(
     ],
     install_requires=__requirements__,
     packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'pyprocessing = pyprocessing.__main__'
+        ]
+    },
     python_requires='>=3.7'
 )


### PR DESCRIPTION
This PR adds the capability to run using the command `pyprocessing /path/to/sketch.py`