### PR TITLE
Fix permission issue when importing package from home directory.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,3 +11,5 @@
 * [Min Shin Khant](https://github.com/minshinkhant)
 
 * [James McClure](https://github.com/PeanutbutterWarrior)
+
+* [jeacom25b](https://github.com/jeacom25b)

--- a/pyprocessing/pyprocessing.py
+++ b/pyprocessing/pyprocessing.py
@@ -69,7 +69,7 @@ class PyProcessing(metaclass=SingletonMeta):
                 ).expanduser()
         if system == 'Linux':
             path = pathlib.Path(
-                    f'/var/logs/pyprocessing/{filename}.log'
+                    f'~/pyprocessing/{filename}.log'
                 ).expanduser()
 
         if path:


### PR DESCRIPTION
This fixes a permission issue that happens when you try to import the package, locally by adding its path to PYTHONPATH and importing it as non-root user;